### PR TITLE
Now there is only one project instead of multiple ones

### DIFF
--- a/CommonLibrary/AsyncCommand.cs
+++ b/CommonLibrary/AsyncCommand.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-namespace CommonLibrary
+namespace MVVMLibrary
 {
     /// <summary>
     /// Copied from https://msdn.microsoft.com/en-us/magazine/dn630647.aspx

--- a/CommonLibrary/AsyncCommandBase.cs
+++ b/CommonLibrary/AsyncCommandBase.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using System.Windows.Input;
 
-namespace CommonLibrary
+namespace MVVMLibrary
 {
     /// <summary>
     /// Copied from https://msdn.microsoft.com/en-us/magazine/dn630647.aspx

--- a/CommonLibrary/BindableCommand.cs
+++ b/CommonLibrary/BindableCommand.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace MVVMLibrary
+{
+    public class BindableCommand<T> : ICommand
+    {
+        public BindableCommand(Action<T> parameterizedAction)
+        {
+            methodToExecute = parameterizedAction;
+        }
+        public BindableCommand(Action<T> parameterizedAction, Func<T, bool> canExecute)
+        {
+            methodToExecute = parameterizedAction;
+            canExecuteMethod = canExecute;
+        }
+
+
+        private Action<T> methodToExecute;
+        private Func<T, bool> canExecuteMethod;
+
+
+        public void RaiseCanExecuteChanged()
+        {
+            CanExecuteChanged(this, EventArgs.Empty);
+        }
+
+
+        #region ICommand
+
+        public bool CanExecute(object parameter)
+        {
+            if (canExecuteMethod != null)
+            {
+                return canExecuteMethod((T)parameter);
+            }
+            if (methodToExecute != null)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public event EventHandler CanExecuteChanged;
+
+        public void Execute(object parameter)
+        {
+            if (methodToExecute != null)
+            {
+                methodToExecute((T)parameter);
+            }
+        }
+
+        #endregion
+    }
+
+
+
+    public class BindableCommand : ICommand
+    {
+        public BindableCommand(Action actionToExecute)
+        {
+            methodToExecute = actionToExecute;
+        }
+        public BindableCommand(Action actionToExecute, Func<bool> canExecute)
+        {
+            methodToExecute = actionToExecute;
+            canExecuteMethod = canExecute;
+        }
+
+
+        private Action methodToExecute;
+        private Func<bool> canExecuteMethod;
+
+
+        public void RaiseCanExecuteChanged()
+        {
+            CanExecuteChanged(this, EventArgs.Empty);
+        }
+
+
+        #region ICommand
+
+        public bool CanExecute(object parameter)
+        {
+            if (canExecuteMethod != null)
+            {
+                return canExecuteMethod();
+            }
+            if (methodToExecute != null)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public event EventHandler CanExecuteChanged;
+
+        public void Execute(object parameter)
+        {
+            if (methodToExecute != null)
+            {
+                methodToExecute();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/CommonLibrary/CommonBase.cs
+++ b/CommonLibrary/CommonBase.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace CommonLibrary
+namespace MVVMLibrary
 {
     public class CommonBase : INotifyPropertyChanged
     {

--- a/CommonLibrary/IAsyncCommand.cs
+++ b/CommonLibrary/IAsyncCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using System.Windows.Input;
 
-namespace CommonLibrary
+namespace MVVMLibrary
 {
     /// <summary>
     /// Copied from https://msdn.microsoft.com/en-us/magazine/dn630647.aspx

--- a/CommonLibrary/MVVMLibrary.csproj
+++ b/CommonLibrary/MVVMLibrary.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{3B31423A-CC27-44BB-9D19-A5DA92D0326D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CommonLibrary</RootNamespace>
+    <RootNamespace>MVVMLibrary</RootNamespace>
     <AssemblyName>CommonLibrary</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -43,9 +44,11 @@
   <ItemGroup>
     <Compile Include="AsyncCommand.cs" />
     <Compile Include="AsyncCommandBase.cs" />
+    <Compile Include="BindableCommand.cs" />
     <Compile Include="CommonBase.cs" />
     <Compile Include="IAsyncCommand.cs" />
     <Compile Include="NotifyTaskCompletion.cs" />
+    <Compile Include="NullToVisibilityConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ValidatableBase.cs" />
   </ItemGroup>

--- a/CommonLibrary/NotifyTaskCompletion.cs
+++ b/CommonLibrary/NotifyTaskCompletion.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
 
-namespace CommonLibrary
+namespace MVVMLibrary
 {
     /// <summary>
     /// Copied from https://msdn.microsoft.com/en-us/magazine/dn630647.aspx

--- a/CommonLibrary/NullToVisibilityConverter.cs
+++ b/CommonLibrary/NullToVisibilityConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace MVVMLibrary
+{
+    public sealed class NullToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value == null ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/CommonLibrary/ValidatableBase.cs
+++ b/CommonLibrary/ValidatableBase.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Numerics;
 using System.Security.Cryptography;
 
-namespace CommonLibrary
+namespace MVVMLibrary
 {
     public class ValidatableBase : CommonBase, INotifyDataErrorInfo
     {

--- a/ViewModels/ViewModels.csproj
+++ b/ViewModels/ViewModels.csproj
@@ -54,10 +54,6 @@
       <Project>{3b31423a-cc27-44bb-9d19-a5da92d0326d}</Project>
       <Name>CommonLibrary</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Models\Models.csproj">
-      <Project>{a4a90329-5662-4e94-86b2-2b71c2e14c85}</Project>
-      <Name>Models</Name>
-    </ProjectReference>
     <ProjectReference Include="..\WalletServices\WalletServices.csproj">
       <Project>{1a172fe1-5923-4c3a-b427-bc68fac05d42}</Project>
       <Name>WalletServices</Name>

--- a/WalletServices/WalletServices.csproj
+++ b/WalletServices/WalletServices.csproj
@@ -55,10 +55,6 @@
       <Project>{3b31423a-cc27-44bb-9d19-a5da92d0326d}</Project>
       <Name>CommonLibrary</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Models\Models.csproj">
-      <Project>{a4a90329-5662-4e94-86b2-2b71c2e14c85}</Project>
-      <Name>Models</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/WatchOnlyBitcoinWallet.sln
+++ b/WatchOnlyBitcoinWallet.sln
@@ -5,13 +5,7 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WatchOnlyBitcoinWallet", "WatchOnlyBitcoinWallet\WatchOnlyBitcoinWallet.csproj", "{3E275526-08A4-4B6B-8E69-9C6194198220}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ViewModels", "ViewModels\ViewModels.csproj", "{E2AA6C6F-B436-4A25-B4D4-CD55214FD8FF}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Models", "Models\Models.csproj", "{A4A90329-5662-4E94-86B2-2B71C2E14C85}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WalletServices", "WalletServices\WalletServices.csproj", "{1A172FE1-5923-4C3A-B427-BC68FAC05D42}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonLibrary", "CommonLibrary\CommonLibrary.csproj", "{3B31423A-CC27-44BB-9D19-A5DA92D0326D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MVVMLibrary", "CommonLibrary\MVVMLibrary.csproj", "{3B31423A-CC27-44BB-9D19-A5DA92D0326D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,18 +17,6 @@ Global
 		{3E275526-08A4-4B6B-8E69-9C6194198220}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E275526-08A4-4B6B-8E69-9C6194198220}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E275526-08A4-4B6B-8E69-9C6194198220}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E2AA6C6F-B436-4A25-B4D4-CD55214FD8FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E2AA6C6F-B436-4A25-B4D4-CD55214FD8FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E2AA6C6F-B436-4A25-B4D4-CD55214FD8FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E2AA6C6F-B436-4A25-B4D4-CD55214FD8FF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A4A90329-5662-4E94-86B2-2B71C2E14C85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A4A90329-5662-4E94-86B2-2B71C2E14C85}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A4A90329-5662-4E94-86B2-2B71C2E14C85}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A4A90329-5662-4E94-86B2-2B71C2E14C85}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1A172FE1-5923-4C3A-B427-BC68FAC05D42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1A172FE1-5923-4C3A-B427-BC68FAC05D42}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1A172FE1-5923-4C3A-B427-BC68FAC05D42}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1A172FE1-5923-4C3A-B427-BC68FAC05D42}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3B31423A-CC27-44BB-9D19-A5DA92D0326D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3B31423A-CC27-44BB-9D19-A5DA92D0326D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B31423A-CC27-44BB-9D19-A5DA92D0326D}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/WatchOnlyBitcoinWallet/App.xaml
+++ b/WatchOnlyBitcoinWallet/App.xaml
@@ -1,12 +1,8 @@
 ﻿<Application x:Class="WatchOnlyBitcoinWallet.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:vm="clr-namespace:ViewModels;assembly=ViewModels"
-             xmlns:v="clr-namespace:WatchOnlyBitcoinWallet"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-        <DataTemplate DataType="{x:Type vm:SettingsWindowViewModel}">
-            <v:SettingsView/>
-        </DataTemplate>
+
     </Application.Resources>
 </Application>

--- a/WatchOnlyBitcoinWallet/MainWindow.xaml
+++ b/WatchOnlyBitcoinWallet/MainWindow.xaml
@@ -1,13 +1,11 @@
 ﻿<Window x:Name="windowMain" x:Class="WatchOnlyBitcoinWallet.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:vm="clr-namespace:ViewModels;assembly=ViewModels"
-        DataContext="{DynamicResource MainWindowViewModel}"
+        xmlns:vm="clr-namespace:WatchOnlyBitcoinWallet.ViewModels"
         Title="Watch Only Bitcoin Wallet - Version 2" Height="332" Width="692" WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize" FontSize="14" Icon="myICO.ico">
-    <Window.Resources>
-        <vm:MainWindowViewModel x:Key="MainWindowViewModel"/>
-        <vm:NullToVisibilityConverter x:Key="NullToVisibilityConverter"/>
-    </Window.Resources>
+    <Window.DataContext>
+        <vm:MainWindowViewModel/>
+    </Window.DataContext>
     <Window.CommandBindings>
         <CommandBinding Command="New" Executed="About_Click"/>
     </Window.CommandBindings>

--- a/WatchOnlyBitcoinWallet/Models/BitcoinAddress.cs
+++ b/WatchOnlyBitcoinWallet/Models/BitcoinAddress.cs
@@ -1,0 +1,59 @@
+﻿using MVVMLibrary;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WatchOnlyBitcoinWallet.Models
+{
+    public class BitcoinAddress : ValidatableBase
+    {
+        /// <summary>
+        /// Name acts as a tag for the address
+        /// </summary>
+        private string name;
+        public string Name
+        {
+            get { return name; }
+            set
+            {
+                if (name != value)
+                {
+                    name = value;
+                    RaisePropertyChanged("Name");
+                }
+            }
+        }
+
+        private string address;
+        public string Address
+        {
+            get { return address; }
+            set
+            {
+                if (address != value)
+                {
+                    address = value;
+                    // Check to see if input is a valid bitcoin address
+                    Validate(value);
+                    RaisePropertyChanged("Address");
+                }
+            }
+        }
+
+        private decimal balance;
+        public decimal Balance
+        {
+            get { return balance; }
+            set
+            {
+                if (balance != value)
+                {
+                    balance = value;
+                    RaisePropertyChanged("Balance");
+                }
+            }
+        }
+    }
+}

--- a/WatchOnlyBitcoinWallet/Models/SettingsModel.cs
+++ b/WatchOnlyBitcoinWallet/Models/SettingsModel.cs
@@ -1,0 +1,16 @@
+﻿using MVVMLibrary;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WatchOnlyBitcoinWallet.Models
+{
+    public class SettingsModel : CommonBase
+    {
+        public decimal BitcoinPriceInUSD { get; set; }
+        public decimal DollarPriceInLocalCurrency { get; set; }
+        public string LocalCurrencySymbol { get; set; }
+    }
+}

--- a/WatchOnlyBitcoinWallet/Services/ApiCall.cs
+++ b/WatchOnlyBitcoinWallet/Services/ApiCall.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using System.Net.Http;
+using Newtonsoft.Json.Linq;
+
+namespace WatchOnlyBitcoinWallet.Services
+{
+    public class ApiCall
+    {
+        public static async Task<JObject> GetApiResponse(string reqUri)
+        {
+            using (var client = new HttpClient())
+            {
+                try
+                {
+                    string result = await client.GetStringAsync(reqUri);
+                    return JObject.Parse(result);
+                }
+                catch (Exception)
+                {
+                    return null;
+                }
+            }
+        }
+    }
+
+}

--- a/WatchOnlyBitcoinWallet/Services/BlockchainInfoService.cs
+++ b/WatchOnlyBitcoinWallet/Services/BlockchainInfoService.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WatchOnlyBitcoinWallet.Models;
+
+namespace WatchOnlyBitcoinWallet.Services
+{
+    public class BlockchainInfoService : ApiCall
+    {
+        public static async Task<bool> GetBalace(List<BitcoinAddress> bitAddrList)
+        {
+            bool IsBalanceChanged = false;
+            foreach (var bitAddr in bitAddrList)
+            {
+                string url = "https://blockchain.info/address/" + bitAddr.Address + "?format=json&limit=0";
+                JObject jResult = await GetApiResponse(url);
+                decimal satoshi = 0.00000001m;
+                decimal bal = (int)jResult["final_balance"] * satoshi;
+                if (bitAddr.Balance != bal)
+                {
+                    bitAddr.Balance = bal;
+                    IsBalanceChanged = true;
+                }
+            }
+            return IsBalanceChanged;
+        }
+    }
+}

--- a/WatchOnlyBitcoinWallet/Services/PriceServices.cs
+++ b/WatchOnlyBitcoinWallet/Services/PriceServices.cs
@@ -1,0 +1,40 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WatchOnlyBitcoinWallet.Services
+{
+    public class PriceServices : ApiCall
+    {
+        public enum ServiceNames
+        {
+            Bitfinex,
+            Btce
+        }
+
+        public static async Task<decimal> GetPrice(string serviceName)
+        {
+            JObject jResult;
+            decimal price;
+            var name = Enum.Parse(typeof(ServiceNames), serviceName);
+            switch ((ServiceNames)name)
+            {
+                case ServiceNames.Bitfinex:
+                    jResult = await GetApiResponse("https://api.bitfinex.com/v1/pubticker/btcusd");
+                    price = (decimal)jResult["last_price"];
+                    break;
+                case ServiceNames.Btce:
+                    jResult = await GetApiResponse("https://btc-e.com/api/3/ticker/btc_usd");
+                    price = (decimal)jResult["btc_usd"]["last"];
+                    break;
+                default:
+                    price = 0;
+                    break;
+            }
+            return price;
+        }
+    }
+}

--- a/WatchOnlyBitcoinWallet/Services/WalletData.cs
+++ b/WatchOnlyBitcoinWallet/Services/WalletData.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+
+using System.IO;
+using System.Xml.Serialization;
+using WatchOnlyBitcoinWallet.Models;
+
+namespace WatchOnlyBitcoinWallet.Services
+{
+    public class WalletData
+    {
+        private static string WalletFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + @"\C.E. Watch Only Bitcoin Wallet";
+        private static string WalletFilePath = WalletFolderPath + @"\BitcoinBalance - Info.txt";
+        private static string SettingFilePath = WalletFolderPath + @"\BitcoinBalance - Settings.txt";
+
+
+        public static List<BitcoinAddress> LoadAddresses()
+        {
+            if (!File.Exists(WalletFilePath))
+            {
+                if (!Directory.Exists(WalletFolderPath))
+                {
+                    Directory.CreateDirectory(WalletFolderPath);
+                }
+                List<BitcoinAddress> emptyList = new List<BitcoinAddress>();
+                Save(emptyList);
+                return emptyList;
+            }
+            else
+            {
+                XmlSerializer ser = new XmlSerializer(typeof(List<BitcoinAddress>));
+                using (StreamReader st = new StreamReader(WalletFilePath))
+                {
+                    return (List<BitcoinAddress>)ser.Deserialize(st);
+                }
+            }
+        }
+        public static void Save(List<BitcoinAddress> BitAddList)
+        {
+            XmlSerializer ser = new XmlSerializer(typeof(List<BitcoinAddress>));
+            using (Stream str = File.Create(WalletFilePath))
+            {
+                ser.Serialize(str, BitAddList);
+            }
+        }
+
+        public static SettingsModel LoadSettings()
+        {
+            if (!File.Exists(SettingFilePath))
+            {
+                SettingsModel emptySettings = new SettingsModel();
+                SaveSettings(emptySettings);
+                return emptySettings;
+            }
+            else
+            {
+                XmlSerializer ser = new XmlSerializer(typeof(SettingsModel));
+                using (StreamReader st = new StreamReader(SettingFilePath))
+                {
+                    return (SettingsModel)ser.Deserialize(st);
+                }
+            }
+        }
+        public static void SaveSettings(SettingsModel settings)
+        {
+            XmlSerializer ser = new XmlSerializer(typeof(SettingsModel));
+            using (Stream str = File.Create(SettingFilePath))
+            {
+                ser.Serialize(str, settings);
+            }
+        }
+    }
+}

--- a/WatchOnlyBitcoinWallet/Services/WindowManager.cs
+++ b/WatchOnlyBitcoinWallet/Services/WindowManager.cs
@@ -1,0 +1,23 @@
+﻿using System.Windows;
+
+using MVVMLibrary;
+using WatchOnlyBitcoinWallet.Views;
+
+namespace WatchOnlyBitcoinWallet.Services
+{
+    public interface IWindowManager
+    {
+        void Show(CommonBase ViewModel);
+    }
+
+    public class SettingsWindowManager : IWindowManager
+    {
+        public void Show(CommonBase ViewModel)
+        {
+            SettingsWindow myWin = new SettingsWindow();
+            myWin.DataContext = ViewModel;
+            myWin.Owner = Application.Current.MainWindow;
+            myWin.ShowDialog();
+        }
+    }
+}

--- a/WatchOnlyBitcoinWallet/ViewModels/MainWindowViewModel.cs
+++ b/WatchOnlyBitcoinWallet/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,203 @@
+﻿using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using MVVMLibrary;
+using WatchOnlyBitcoinWallet.Models;
+using WatchOnlyBitcoinWallet.Services;
+
+namespace WatchOnlyBitcoinWallet.ViewModels
+{
+    public class MainWindowViewModel : CommonBase
+    {
+        public MainWindowViewModel()
+        {
+            AddressList = new BindingList<BitcoinAddress>(WalletData.LoadAddresses());
+            AddressList.ListChanged += AddressList_ListChanged;
+
+            SettingsInstance = WalletData.LoadSettings();
+
+            GetBalanceCommand = AsyncCommand.Create(() => GetBalance());
+            SaveCommand = new BindableCommand(() => Save());
+            SettingsCommand = new BindableCommand(() => OpenSettings());
+        }
+
+
+        /// <summary>
+        /// List of all available addresses in the wallet.
+        /// </summary>
+        public BindingList<BitcoinAddress> AddressList { get; set; }
+
+        private void AddressList_ListChanged(object sender, ListChangedEventArgs e)
+        {
+            if (e.ListChangedType == ListChangedType.ItemChanged)
+            {
+                var addrs = (BindingList<BitcoinAddress>)sender;
+                StringBuilder sb = new StringBuilder();
+                foreach (var item in addrs)
+                {
+                    if (item.HasErrors)
+                    {
+                        foreach (var er in item.GetErrors("Address"))
+                        {
+                            sb.Append(er);
+                        }
+                    }
+                }
+                MessageToDisplay = sb.ToString();
+
+                IsSaveButtonEnabled = (sb.Length != 0) ? false : true;
+            }
+        }
+
+        private string messageToDisplay;
+        public string MessageToDisplay
+        {
+            get { return messageToDisplay; }
+            set
+            {
+                if (messageToDisplay != value)
+                {
+                    messageToDisplay = value;
+                    RaisePropertyChanged("MessageToDisplay");
+                }
+            }
+        }
+
+        private SettingsModel settingsInstance;
+        public SettingsModel SettingsInstance
+        {
+            get { return settingsInstance; }
+            set
+            {
+                if (settingsInstance != value)
+                {
+                    settingsInstance = value;
+                    RaisePropertyChanged("SettingsInstance");
+                }
+            }
+        }
+
+
+        private decimal bitcoinBalance;
+        public decimal BitcoinBalance
+        {
+            get
+            {
+                bitcoinBalance = AddressList.Sum(x => (decimal)x.Balance);
+                return bitcoinBalance;
+            }
+            set
+            {
+                if (bitcoinBalance != value)
+                {
+                    bitcoinBalance = value;
+                    RaisePropertyChanged("BitcoinBalance");
+                    RaisePropertyChanged("BitcoinBalanceUSD");
+                    RaisePropertyChanged("BitcoinBalanceLC");
+                }
+            }
+        }
+
+        private decimal bitcoinBalanceUSD;
+        public decimal BitcoinBalanceUSD
+        {
+            get
+            {
+                bitcoinBalanceUSD = bitcoinBalance * SettingsInstance.BitcoinPriceInUSD;
+                return bitcoinBalanceUSD;
+            }
+            set
+            {
+                if (bitcoinBalanceUSD != value)
+                {
+                    bitcoinBalanceUSD = value;
+                    RaisePropertyChanged("BitcoinBalanceUSD");
+                }
+            }
+        }
+
+        private decimal bitcoinBalanceLC;
+        public decimal BitcoinBalanceLC
+        {
+            get
+            {
+                bitcoinBalanceLC = bitcoinBalanceUSD * SettingsInstance.DollarPriceInLocalCurrency;
+                return bitcoinBalanceLC;
+            }
+            set
+            {
+                if (bitcoinBalanceLC != value)
+                {
+                    bitcoinBalanceLC = value;
+                    RaisePropertyChanged("BitcoinBalanceLC");
+                }
+            }
+        }
+
+        private string localCurrencySymbol;
+        public string LocalCurrencySymbol
+        {
+            get
+            {
+                localCurrencySymbol = SettingsInstance.LocalCurrencySymbol;
+                return localCurrencySymbol;
+            }
+            set
+            {
+                if (localCurrencySymbol != value)
+                {
+                    localCurrencySymbol = value;
+                    RaisePropertyChanged("LocalCurrencySymbol");
+                }
+            }
+        }
+
+
+
+        public BindableCommand SettingsCommand { get; private set; }
+        private void OpenSettings()
+        {
+            IWindowManager winManager = new SettingsWindowManager();
+            SettingsViewModel vm = new SettingsViewModel();
+            vm.Settings = SettingsInstance;
+            winManager.Show(vm);
+        }
+
+
+        public IAsyncCommand GetBalanceCommand { get; private set; }
+        private async Task GetBalance()
+        {
+            bool isChanged = await BlockchainInfoService.GetBalace(AddressList.ToList());
+            if (isChanged)
+            {
+                RaisePropertyChanged("BitcoinBalance");
+                RaisePropertyChanged("BitcoinBalanceUSD");
+                RaisePropertyChanged("BitcoinBalanceLC");
+            }
+        }
+
+
+        public BindableCommand SaveCommand { get; private set; }
+        private void Save()
+        {
+            WalletData.Save(AddressList.ToList());
+            IsSaveButtonEnabled = false;
+        }
+
+        private bool isSaveButtonEnabled;
+        public bool IsSaveButtonEnabled
+        {
+            get { return isSaveButtonEnabled; }
+            set
+            {
+                if (isSaveButtonEnabled != value)
+                {
+                    isSaveButtonEnabled = value;
+                    RaisePropertyChanged("IsSaveButtonEnabled");
+                }
+            }
+        }
+    }
+}

--- a/WatchOnlyBitcoinWallet/ViewModels/SettingsViewModel.cs
+++ b/WatchOnlyBitcoinWallet/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Collections.ObjectModel;
+using MVVMLibrary;
+using WatchOnlyBitcoinWallet.Models;
+using WatchOnlyBitcoinWallet.Services;
+
+namespace WatchOnlyBitcoinWallet.ViewModels
+{
+    public class SettingsViewModel : CommonBase
+    {
+        public SettingsViewModel()
+        {
+            Settings = new SettingsModel();
+
+            PriceServiceList = new ObservableCollection<string>(Enum.GetNames(typeof(PriceServices.ServiceNames)));
+            SelectedPriceService = Enum.GetName(typeof(PriceServices.ServiceNames), PriceServices.ServiceNames.Bitfinex);
+
+            GetPriceCommand = AsyncCommand.Create(() => GetPrice());
+            SaveCommand = new BindableCommand(() => Save());
+        }
+
+        public IAsyncCommand GetPriceCommand { get; private set; }
+        private async Task GetPrice()
+        {
+            decimal price = await PriceServices.GetPrice(SelectedPriceService);
+            BitcoinPrice = price;
+        }
+
+        public BindableCommand SaveCommand { get; private set; }
+        private void Save()
+        {
+            WalletData.SaveSettings(Settings);
+            IsSaveButtonEnabled = false;
+        }
+
+        private bool isSaveButtonEnabled;
+        public bool IsSaveButtonEnabled
+        {
+            get { return isSaveButtonEnabled; }
+            set
+            {
+                if (isSaveButtonEnabled != value)
+                {
+                    isSaveButtonEnabled = value;
+                    RaisePropertyChanged("IsSaveButtonEnabled");
+                }
+            }
+        }
+
+
+        private ObservableCollection<string> priceServiceList;
+        public ObservableCollection<string> PriceServiceList
+        {
+            get { return priceServiceList; }
+            set
+            {
+                if (priceServiceList != value)
+                {
+                    priceServiceList = value;
+                    RaisePropertyChanged("PriceServiceList");
+                }
+            }
+        }
+
+        private string selectedPriceService;
+        public string SelectedPriceService
+        {
+            get { return selectedPriceService; }
+            set
+            {
+                if (selectedPriceService != value)
+                {
+                    selectedPriceService = value;
+                    RaisePropertyChanged("SelectedPriceService");
+                }
+            }
+        }
+
+
+        private SettingsModel settings;
+        public SettingsModel Settings
+        {
+            get { return settings; }
+            set
+            {
+                if (settings != value)
+                {
+                    settings = value;
+                    RaisePropertyChanged("Settings");
+                    IsSaveButtonEnabled = true;
+                }
+            }
+        }
+
+        public decimal BitcoinPrice
+        {
+            get
+            {
+                return Settings.BitcoinPriceInUSD;
+            }
+            set
+            {
+                if (Settings.BitcoinPriceInUSD != value)
+                {
+                    Settings.BitcoinPriceInUSD = value;
+                    RaisePropertyChanged("BitcoinPrice");
+                    IsSaveButtonEnabled = true;
+                }
+            }
+        }
+
+        public decimal USDPrice
+        {
+            get
+            {
+                return Settings.DollarPriceInLocalCurrency;
+            }
+            set
+            {
+                if (Settings.DollarPriceInLocalCurrency != value)
+                {
+                    Settings.DollarPriceInLocalCurrency = value;
+                    RaisePropertyChanged("USDPrice");
+                    IsSaveButtonEnabled = true;
+                }
+            }
+        }
+
+        public string LocalCurrencySymbol
+        {
+            get
+            {
+                return Settings.LocalCurrencySymbol;
+            }
+            set
+            {
+                if (Settings.LocalCurrencySymbol != value)
+                {
+                    Settings.LocalCurrencySymbol = value;
+                    RaisePropertyChanged("LocalCurrencySymbol");
+                    IsSaveButtonEnabled = true;
+                }
+            }
+        }
+    }
+}

--- a/WatchOnlyBitcoinWallet/Views/SettingsWindow.xaml
+++ b/WatchOnlyBitcoinWallet/Views/SettingsWindow.xaml
@@ -1,14 +1,12 @@
-﻿<UserControl x:Class="WatchOnlyBitcoinWallet.SettingsView"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:vm="clr-namespace:ViewModels;assembly=ViewModels"
-             mc:Ignorable="d" 
-             d:DesignHeight="174.5" d:DesignWidth="322" FontSize="14">
+﻿<Window x:Class="WatchOnlyBitcoinWallet.Views.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:WatchOnlyBitcoinWallet.ViewModels"
+        Title="Settings" Height="174.5" Width="322" FontSize="14" Icon="/WatchOnlyBitcoinWallet;component/myICO.ico" ResizeMode="NoResize" ShowInTaskbar="False" WindowStartupLocation="CenterOwner">
+    <Window.DataContext>
+        <vm:SettingsViewModel/>
+    </Window.DataContext>
     <Grid>
-        <ContentControl Content="{Binding vm:SettingsWindowViewModel}"/>
-        
         <TextBox HorizontalAlignment="Left" Height="25" Margin="75,10,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="120" Text="{Binding BitcoinPrice, UpdateSourceTrigger=PropertyChanged}"/>
         <TextBox HorizontalAlignment="Left" Height="25" Margin="75,40,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="120" Text="{Binding USDPrice, UpdateSourceTrigger=PropertyChanged}"/>
         <TextBox HorizontalAlignment="Left" Height="25" Margin="75,70,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="120" Text="{Binding LocalCurrencySymbol}"/>
@@ -23,4 +21,4 @@
         <ComboBox HorizontalAlignment="Left" Margin="74,103,0,0" VerticalAlignment="Top" Width="120" ItemsSource="{Binding PriceServiceList}" SelectedItem="{Binding SelectedPriceService}"/>
         <Button Content="Update" HorizontalAlignment="Left" Margin="9,103,0,0" VerticalAlignment="Top" Width="60" Command="{Binding GetPriceCommand, Mode=OneWay}"/>
     </Grid>
-</UserControl>
+</Window>

--- a/WatchOnlyBitcoinWallet/Views/SettingsWindow.xaml.cs
+++ b/WatchOnlyBitcoinWallet/Views/SettingsWindow.xaml.cs
@@ -10,17 +10,16 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
 using System.Windows.Shapes;
 
-namespace WatchOnlyBitcoinWallet
+namespace WatchOnlyBitcoinWallet.Views
 {
     /// <summary>
-    /// Interaction logic for SettingsView.xaml
+    /// Interaction logic for SettingsWindow.xaml
     /// </summary>
-    public partial class SettingsView : UserControl
+    public partial class SettingsWindow : Window
     {
-        public SettingsView()
+        public SettingsWindow()
         {
             InitializeComponent();
         }

--- a/WatchOnlyBitcoinWallet/WatchOnlyBitcoinWallet.csproj
+++ b/WatchOnlyBitcoinWallet/WatchOnlyBitcoinWallet.csproj
@@ -37,14 +37,20 @@
     <ApplicationIcon>myICO.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.XML" />
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -57,8 +63,17 @@
     <Compile Include="AboutWindow.xaml.cs">
       <DependentUpon>AboutWindow.xaml</DependentUpon>
     </Compile>
-    <Compile Include="SettingsView.xaml.cs">
-      <DependentUpon>SettingsView.xaml</DependentUpon>
+    <Compile Include="Models\BitcoinAddress.cs" />
+    <Compile Include="Models\SettingsModel.cs" />
+    <Compile Include="Services\ApiCall.cs" />
+    <Compile Include="Services\BlockchainInfoService.cs" />
+    <Compile Include="Services\PriceServices.cs" />
+    <Compile Include="Services\WalletData.cs" />
+    <Compile Include="Services\WindowManager.cs" />
+    <Compile Include="ViewModels\MainWindowViewModel.cs" />
+    <Compile Include="ViewModels\SettingsViewModel.cs" />
+    <Compile Include="Views\SettingsWindow.xaml.cs">
+      <DependentUpon>SettingsWindow.xaml</DependentUpon>
     </Compile>
     <Page Include="AboutWindow.xaml">
       <SubType>Designer</SubType>
@@ -76,7 +91,7 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
-    <Page Include="SettingsView.xaml">
+    <Page Include="Views\SettingsWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -99,6 +114,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -112,15 +128,12 @@
     <Resource Include="myICO.ico" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CommonLibrary\CommonLibrary.csproj">
+    <ProjectReference Include="..\CommonLibrary\MVVMLibrary.csproj">
       <Project>{3b31423a-cc27-44bb-9d19-a5da92d0326d}</Project>
-      <Name>CommonLibrary</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\ViewModels\ViewModels.csproj">
-      <Project>{e2aa6c6f-b436-4a25-b4d4-cd55214fd8ff}</Project>
-      <Name>ViewModels</Name>
+      <Name>MVVMLibrary</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/WatchOnlyBitcoinWallet/packages.config
+++ b/WatchOnlyBitcoinWallet/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Removed extra projects and moved each of them into separate folders inside one project.
Renamed `CommonLibrary` assembly to `MVVMLibrary`
Replaces `RelayCommand` with a better coded `BindableCommand`
Also improved the way `SettingWindow` worked.